### PR TITLE
Fix typo in processing gender arg in several scripts (spelled "female" as "famale").

### DIFF
--- a/dnanexus/prep-rsem/resources/usr/bin/lrna_index_rsem.sh
+++ b/dnanexus/prep-rsem/resources/usr/bin/lrna_index_rsem.sh
@@ -28,7 +28,7 @@ anno_root=${anno_gtf%.gtf}
 gunzip $anno_gtf_gz
 
 archive_file="${genome}_${anno}_${spike_root}_rsemIndex.tgz"
-if [ "$gender" == "famale" ] || [ "$gender" == "male" ] || [ "$gender" == "XX" ] || [ "$gender" == "XY" ]; then
+if [ "$gender" == "female" ] || [ "$gender" == "male" ] || [ "$gender" == "XX" ] || [ "$gender" == "XY" ]; then
     archive_file="${genome}_${gender}_${anno}_${spike_root}_rsemIndex.tgz"
 fi
 echo "-- Results will be: '${archive_file}'."

--- a/dnanexus/prep-rsem/src/prep-rsem.sh
+++ b/dnanexus/prep-rsem/src/prep-rsem.sh
@@ -93,7 +93,7 @@ main() {
     set +x
     echo "* ===== Returned from dnanexus and encodeD independent script ====="
     archive_file="${genome}_${anno}_${spike_root}_rsemIndex.tgz"
-    if [ "$gender" == "famale" ] || [ "$gender" == "male" ] || [ "$gender" == "XX" ] || [ "$gender" == "XY" ]; then
+    if [ "$gender" == "female" ] || [ "$gender" == "male" ] || [ "$gender" == "XX" ] || [ "$gender" == "XY" ]; then
         archive_file="${genome}_${gender}_${anno}_${spike_root}_rsemIndex.tgz"
     fi
 

--- a/dnanexus/prep-star/resources/usr/bin/lrna_index_star.sh
+++ b/dnanexus/prep-star/resources/usr/bin/lrna_index_star.sh
@@ -28,7 +28,7 @@ anno_root=${anno_gtf%.gtf}
 gunzip $anno_gtf_gz
 
 archive_file="${genome}_${anno}_${spike_root}_starIndex.tgz"
-if [ "$gender" == "famale" ] || [ "$gender" == "male" ] || [ "$gender" == "XX" ] || [ "$gender" == "XY" ]; then
+if [ "$gender" == "female" ] || [ "$gender" == "male" ] || [ "$gender" == "XX" ] || [ "$gender" == "XY" ]; then
     archive_file="${genome}_${gender}_${anno}_${spike_root}_starIndex.tgz"
 fi
 echo "-- Results will be: '${archive_file}'."

--- a/dnanexus/prep-star/src/prep-star.sh
+++ b/dnanexus/prep-star/src/prep-star.sh
@@ -92,7 +92,7 @@ main() {
     set +x
     echo "* ===== Returned from dnanexus and encodeD independent script ====="
     archive_file="${genome}_${anno}_${spike_root}_starIndex.tgz"
-    if [ "$gender" == "famale" ] || [ "$gender" == "male" ] || [ "$gender" == "XX" ] || [ "$gender" == "XY" ]; then
+    if [ "$gender" == "female" ] || [ "$gender" == "male" ] || [ "$gender" == "XX" ] || [ "$gender" == "XY" ]; then
         archive_file="${genome}_${gender}_${anno}_${spike_root}_starIndex.tgz"
     fi
 

--- a/dnanexus/prep-tophat/resources/usr/bin/lrna_index_tophat.sh
+++ b/dnanexus/prep-tophat/resources/usr/bin/lrna_index_tophat.sh
@@ -31,7 +31,7 @@ tiny_fq=${tiny_fq_gz%.gz}
 gunzip $tiny_fq_gz
 
 archive_file="${genome}_${anno}_${spike_root}_tophatIndex.tgz"
-if [ "$gender" == "famale" ] || [ "$gender" == "male" ] || [ "$gender" == "XX" ] || [ "$gender" == "XY" ]; then
+if [ "$gender" == "female" ] || [ "$gender" == "male" ] || [ "$gender" == "XX" ] || [ "$gender" == "XY" ]; then
     archive_file="${genome}_${gender}_${anno}_${spike_root}_tophatIndex.tgz"
 fi
 echo "-- Results will be: '${archive_file}'."

--- a/dnanexus/prep-tophat/src/prep-tophat.sh
+++ b/dnanexus/prep-tophat/src/prep-tophat.sh
@@ -104,7 +104,7 @@ main() {
     set +x
     echo "* ===== Returned from dnanexus and encodeD independent script ====="
     archive_file="${genome}_${anno}_${spike_root}_tophatIndex.tgz"
-    if [ "$gender" == "famale" ] || [ "$gender" == "male" ] || [ "$gender" == "XX" ] || [ "$gender" == "XY" ]; then
+    if [ "$gender" == "female" ] || [ "$gender" == "male" ] || [ "$gender" == "XX" ] || [ "$gender" == "XY" ]; then
         archive_file="${genome}_${gender}_${anno}_${spike_root}_tophatIndex.tgz"
     fi
 

--- a/dnanexus/small-rna/small-rna-prep-star/resources/usr/bin/srna_index.sh
+++ b/dnanexus/small-rna/small-rna-prep-star/resources/usr/bin/srna_index.sh
@@ -14,7 +14,7 @@ if [ $# -eq 5 ]; then
 fi
 
 archive_file="${genome}_${anno}_sRNA_starIndex.tgz"
-if [ "$gender" == "famale" ] || [ "$gender" == "male" ] || [ "$gender" == "XX" ] || [ "$gender" == "XY" ]; then
+if [ "$gender" == "female" ] || [ "$gender" == "male" ] || [ "$gender" == "XX" ] || [ "$gender" == "XY" ]; then
     archive_file="${genome}_${gender}_${anno}_sRNA_starIndex.tgz"
 fi
 echo "-- Results will be: '${archive_file}'."

--- a/dnanexus/small-rna/small-rna-prep-star/src/small-rna-prep-star.sh
+++ b/dnanexus/small-rna/small-rna-prep-star/src/small-rna-prep-star.sh
@@ -91,7 +91,7 @@ main() {
     set +x
     echo "* ===== Returned from dnanexus and encodeD independent script ====="
     archive_file="${genome}_${anno}_sRNA_starIndex.tgz"
-    if [ "$gender" == "famale" ] || [ "$gender" == "male" ] || [ "$gender" == "XX" ] || [ "$gender" == "XY" ]; then
+    if [ "$gender" == "female" ] || [ "$gender" == "male" ] || [ "$gender" == "XX" ] || [ "$gender" == "XY" ]; then
         archive_file="${genome}_${gender}_${anno}_sRNA_starIndex.tgz"
     fi
     gene_id_root="${genome}_${anno}_gene_ids"


### PR DESCRIPTION
A bunch of scripts were checking if `"$gender" == "famale"`, not `"female"`.